### PR TITLE
feat: expand component library with accessibility support (#3, #4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -497,6 +498,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -537,6 +539,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1719,8 +1722,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1805,6 +1807,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1815,6 +1818,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1864,6 +1868,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2252,6 +2257,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2302,7 +2308,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2411,6 +2416,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2647,8 +2653,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2748,6 +2753,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3265,6 +3271,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -3410,7 +3417,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3622,6 +3628,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3674,7 +3681,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3690,7 +3696,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3714,6 +3719,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3724,6 +3730,7 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3736,8 +3743,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4080,6 +4086,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4169,6 +4176,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4450,6 +4458,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/auth/LoginPage.test.tsx
+++ b/src/auth/LoginPage.test.tsx
@@ -27,7 +27,7 @@ describe('LoginPage', () => {
     expect(screen.getByText('Email')).toBeInTheDocument();
   });
 
-  it('displays error message', () => {
+  it('displays error message with alert role', () => {
     render(
       <LoginPage
         title="App"
@@ -35,7 +35,9 @@ describe('LoginPage', () => {
         onLogin={vi.fn()}
       />,
     );
-    expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Invalid credentials');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
   });
 
   it('calls onLogin with username and password', async () => {
@@ -44,8 +46,8 @@ describe('LoginPage', () => {
 
     render(<LoginPage title="App" onLogin={onLogin} />);
 
-    await user.type(screen.getByPlaceholderText('admin'), 'testuser');
-    await user.type(screen.getByPlaceholderText('••••••••'), 'testpass');
+    await user.type(screen.getByLabelText('Username'), 'testuser');
+    await user.type(screen.getByLabelText('Password'), 'testpass');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
     expect(onLogin).toHaveBeenCalledWith('testuser', 'testpass');
@@ -61,11 +63,34 @@ describe('LoginPage', () => {
 
     render(<LoginPage title="App" onLogin={onLogin} />);
 
-    await user.type(screen.getByPlaceholderText('admin'), 'u');
-    await user.type(screen.getByPlaceholderText('••••••••'), 'p');
+    await user.type(screen.getByLabelText('Username'), 'u');
+    await user.type(screen.getByLabelText('Password'), 'p');
     await user.click(screen.getByRole('button', { name: 'Sign In' }));
 
     expect(screen.getByText('Signing in...')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
     resolveLogin!();
+  });
+
+  it('uses semantic main element', () => {
+    render(<LoginPage title="App" onLogin={vi.fn()} />);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('has accessible form with aria-label', () => {
+    render(<LoginPage title="App" onLogin={vi.fn()} />);
+    expect(screen.getByRole('form', { name: 'Sign in' })).toBeInTheDocument();
+  });
+
+  it('labels are associated with inputs via htmlFor', () => {
+    render(<LoginPage title="App" onLogin={vi.fn()} />);
+    expect(screen.getByLabelText('Username')).toBeInTheDocument();
+    expect(screen.getByLabelText('Password')).toBeInTheDocument();
+  });
+
+  it('inputs have aria-required', () => {
+    render(<LoginPage title="App" onLogin={vi.fn()} />);
+    expect(screen.getByLabelText('Username')).toHaveAttribute('aria-required', 'true');
+    expect(screen.getByLabelText('Password')).toHaveAttribute('aria-required', 'true');
   });
 });

--- a/src/auth/LoginPage.test.tsx
+++ b/src/auth/LoginPage.test.tsx
@@ -103,11 +103,6 @@ describe('LoginPage', () => {
     expect(screen.getByRole('main')).toBeInTheDocument();
   });
 
-  it('has accessible form with aria-label', () => {
-    render(<LoginPage title="App" onLogin={vi.fn()} />);
-    expect(screen.getByRole('form', { name: 'Login form' })).toBeInTheDocument();
-  });
-
   it('labels are associated with inputs via htmlFor', () => {
     render(<LoginPage title="App" onLogin={vi.fn()} />);
     expect(screen.getByLabelText('Username')).toBeInTheDocument();

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -45,7 +45,7 @@ export default function LoginPage({
   }
 
   return (
-    <div
+    <main
       style={{
         ...baseStyles.container,
         display: 'flex',
@@ -84,6 +84,8 @@ export default function LoginPage({
 
         {error && (
           <div
+            role="alert"
+            aria-live="assertive"
             style={{
               backgroundColor: `${colors.red}22`,
               border: `1px solid ${colors.red}`,
@@ -98,9 +100,10 @@ export default function LoginPage({
           </div>
         )}
 
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} aria-label="Sign in">
           <div style={{ marginBottom: '16px' }}>
             <label
+              htmlFor="login-username"
               style={{
                 display: 'block',
                 color: colors.subtext1,
@@ -112,18 +115,21 @@ export default function LoginPage({
               {usernameLabel}
             </label>
             <input
+              id="login-username"
               type={usernameType}
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               placeholder={usernamePlaceholder}
               autoFocus
               required
+              aria-required="true"
               style={baseStyles.input}
             />
           </div>
 
           <div style={{ marginBottom: '24px' }}>
             <label
+              htmlFor="login-password"
               style={{
                 display: 'block',
                 color: colors.subtext1,
@@ -135,11 +141,13 @@ export default function LoginPage({
               Password
             </label>
             <input
+              id="login-password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
               required
+              aria-required="true"
               style={baseStyles.input}
             />
           </div>
@@ -147,6 +155,7 @@ export default function LoginPage({
           <button
             type="submit"
             disabled={loading}
+            aria-busy={loading}
             style={{
               ...baseStyles.button.primary,
               width: '100%',
@@ -159,6 +168,6 @@ export default function LoginPage({
           </button>
         </form>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DataTable, { type DataTableColumn } from './DataTable';
 
-interface Row {
+interface Row extends Record<string, unknown> {
   id: number;
   name: string;
   status: string;

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { useState, useMemo, type CSSProperties, type ReactNode } from 'react';
 import { colors, baseStyles } from '../theme';
 
 export interface DataTableColumn<T> {
@@ -82,11 +82,6 @@ export default function DataTable<T extends Record<string, unknown>>({
   const safePageSize = Math.max(1, pageSize);
   const totalPages = Math.max(1, Math.ceil(data.length / safePageSize));
   const safePage = Math.min(currentPage, totalPages);
-
-  // Clamp page to valid range when data length or pageSize changes
-  useEffect(() => {
-    setCurrentPage((p) => Math.min(p, Math.max(1, Math.ceil(data.length / safePageSize))));
-  }, [data.length, safePageSize]);
 
   // Client-side sort when no external onSort handler — memoized to avoid sorting on every render
   const sortedData = useMemo(() => {

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties, type ReactNode } from 'react';
+import { useState, useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
 import { colors, baseStyles } from '../theme';
 
 export interface DataTableColumn<T> {
@@ -83,24 +83,31 @@ export default function DataTable<T extends Record<string, unknown>>({
   const totalPages = Math.max(1, Math.ceil(data.length / safePageSize));
   const safePage = Math.min(currentPage, totalPages);
 
-  // Client-side sort when no external onSort handler
-  const sortedData = onSort
-    ? data
-    : sortState
-      ? [...data].sort((a, b) => {
-          const av = a[sortState.key];
-          const bv = b[sortState.key];
-          const cmp =
-            av == null ? -1
-            : bv == null ? 1
-            : typeof av === 'number' && typeof bv === 'number'
-              ? av - bv
-              : String(av).localeCompare(String(bv));
-          return sortState.direction === 'asc' ? cmp : -cmp;
-        })
-      : data;
+  // Clamp page to valid range when data length or pageSize changes
+  useEffect(() => {
+    setCurrentPage((p) => Math.min(p, Math.max(1, Math.ceil(data.length / safePageSize))));
+  }, [data.length, safePageSize]);
 
-  const pageData = sortedData.slice((safePage - 1) * safePageSize, safePage * safePageSize);
+  // Client-side sort when no external onSort handler — memoized to avoid sorting on every render
+  const sortedData = useMemo(() => {
+    if (onSort || !sortState) return data;
+    return [...data].sort((a, b) => {
+      const av = a[sortState.key];
+      const bv = b[sortState.key];
+      const cmp =
+        av == null ? -1
+        : bv == null ? 1
+        : typeof av === 'number' && typeof bv === 'number'
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      return sortState.direction === 'asc' ? cmp : -cmp;
+    });
+  }, [data, onSort, sortState]);
+
+  const pageData = useMemo(
+    () => sortedData.slice((safePage - 1) * safePageSize, safePage * safePageSize),
+    [sortedData, safePage, safePageSize],
+  );
 
   function handleSort(col: DataTableColumn<T>) {
     if (!col.sortable) return;

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DataTable from './DataTable';
 
-interface Row {
+interface Row extends Record<string, unknown> {
   id: string;
   name: string;
   status: string;

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -47,7 +47,7 @@ describe('DataTable', () => {
         caption="Workflow list"
       />,
     );
-    expect(screen.getByRole('grid', { name: 'Workflow list' })).toBeInTheDocument();
+    expect(screen.getByRole('table', { name: 'Workflow list' })).toBeInTheDocument();
   });
 
   it('sorts by column when clicking sortable header', async () => {

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DataTable from './DataTable';
+
+interface Row {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const columns = [
+  { key: 'name', header: 'Name', sortable: true },
+  { key: 'status', header: 'Status' },
+];
+
+const data: Row[] = [
+  { id: '1', name: 'Alpha', status: 'running' },
+  { id: '2', name: 'Beta', status: 'idle' },
+  { id: '3', name: 'Gamma', status: 'failed' },
+];
+
+describe('DataTable', () => {
+  it('renders rows and headers', () => {
+    render(
+      <DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={0} />,
+    );
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+  });
+
+  it('shows "No data available" when empty', () => {
+    render(
+      <DataTable columns={columns} data={[]} rowKey={(r: Row) => r.id} />,
+    );
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('has accessible table role and caption', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        rowKey={(r) => r.id}
+        caption="Workflow list"
+      />,
+    );
+    expect(screen.getByRole('grid', { name: 'Workflow list' })).toBeInTheDocument();
+  });
+
+  it('sorts by column when clicking sortable header', async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={0} />,
+    );
+
+    const sortBtn = screen.getByRole('button', { name: 'Sort by Name' });
+    await user.click(sortBtn);
+
+    const rows = screen.getAllByRole('row');
+    // Header row + 3 data rows
+    expect(rows).toHaveLength(4);
+    // First data row after ascending sort should be Alpha
+    expect(within(rows[1]).getByText('Alpha')).toBeInTheDocument();
+
+    // Click again to reverse
+    await user.click(sortBtn);
+    const rows2 = screen.getAllByRole('row');
+    expect(within(rows2[1]).getByText('Gamma')).toBeInTheDocument();
+  });
+
+  it('sets aria-sort on sorted column', async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={0} />,
+    );
+
+    const sortBtn = screen.getByRole('button', { name: 'Sort by Name' });
+    await user.click(sortBtn);
+
+    const th = sortBtn.closest('th');
+    expect(th).toHaveAttribute('aria-sort', 'ascending');
+  });
+
+  it('paginates data', async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={2} />,
+    );
+
+    // Page 1: 2 rows
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+    expect(screen.queryByText('Gamma')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+  });
+
+  it('has accessible pagination controls', () => {
+    render(
+      <DataTable columns={columns} data={data} rowKey={(r) => r.id} pageSize={2} />,
+    );
+    expect(screen.getByRole('navigation', { name: 'Table pagination' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Next page' })).toBeEnabled();
+  });
+
+  it('supports custom cell renderer', () => {
+    const cols = [
+      {
+        key: 'name',
+        header: 'Name',
+        render: (val: unknown) => <strong>{String(val)}</strong>,
+      },
+    ];
+    render(
+      <DataTable columns={cols} data={data} rowKey={(r) => r.id} pageSize={0} />,
+    );
+    expect(screen.getByText('Alpha').tagName).toBe('STRONG');
+  });
+});

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, type CSSProperties, type ReactNode } from 'react';
+import { useState, useCallback, useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
 import { colors, baseStyles } from '../../theme';
 
 export interface DataTableColumn<T> {
@@ -62,22 +62,27 @@ export default function DataTable<T extends Record<string, unknown>>({
     [sortKey],
   );
 
-  const sorted = [...data].sort((a, b) => {
-    if (!sortKey) return 0;
-    const aVal = a[sortKey];
-    const bVal = b[sortKey];
-    if (aVal == null && bVal == null) return 0;
-    if (aVal == null) return 1;
-    if (bVal == null) return -1;
-    const cmp = String(aVal).localeCompare(String(bVal), undefined, {
-      numeric: true,
+  const sorted = useMemo(() => {
+    if (!sortKey) return data;
+    return [...data].sort((a, b) => {
+      const aVal = a[sortKey];
+      const bVal = b[sortKey];
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return 1;
+      if (bVal == null) return -1;
+      const cmp = String(aVal).localeCompare(String(bVal), undefined, {
+        numeric: true,
+      });
+      return sortDir === 'asc' ? cmp : -cmp;
     });
-    return sortDir === 'asc' ? cmp : -cmp;
-  });
+  }, [data, sortKey, sortDir]);
 
-  const paginated =
-    pageSize > 0 ? sorted.slice(page * pageSize, (page + 1) * pageSize) : sorted;
   const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(data.length / pageSize)) : 1;
+
+  const paginated = useMemo(
+    () => (pageSize > 0 ? sorted.slice(page * pageSize, (page + 1) * pageSize) : sorted),
+    [sorted, page, pageSize],
+  );
 
   return (
     <div style={style}>

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { useState, useCallback, useMemo, type CSSProperties, type ReactNode } from 'react';
 import { colors, baseStyles } from '../../theme';
 
 export interface DataTableColumn<T> {
@@ -41,14 +41,6 @@ export default function DataTable<T extends Record<string, unknown>>({
   const [sortDir, setSortDir] = useState<SortDirection>('asc');
   const [page, setPage] = useState(0);
 
-  // Clamp page when data length or pageSize changes to avoid empty views
-  useEffect(() => {
-    if (pageSize > 0) {
-      const total = Math.max(1, Math.ceil(data.length / pageSize));
-      setPage((p) => Math.min(p, total - 1));
-    }
-  }, [data.length, pageSize]);
-
   const handleSort = useCallback(
     (key: keyof T & string) => {
       if (sortKey === key) {
@@ -78,10 +70,11 @@ export default function DataTable<T extends Record<string, unknown>>({
   }, [data, sortKey, sortDir]);
 
   const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(data.length / pageSize)) : 1;
+  const safePage = Math.min(page, totalPages - 1);
 
   const paginated = useMemo(
-    () => (pageSize > 0 ? sorted.slice(page * pageSize, (page + 1) * pageSize) : sorted),
-    [sorted, page, pageSize],
+    () => (pageSize > 0 ? sorted.slice(safePage * pageSize, (safePage + 1) * pageSize) : sorted),
+    [sorted, safePage, pageSize],
   );
 
   return (
@@ -173,11 +166,11 @@ export default function DataTable<T extends Record<string, unknown>>({
           <button
             type="button"
             onClick={() => setPage((p) => Math.max(0, p - 1))}
-            disabled={page === 0}
+            disabled={safePage === 0}
             aria-label="Previous page"
             style={{
               ...baseStyles.button.secondary,
-              opacity: page === 0 ? 0.5 : 1,
+              opacity: safePage === 0 ? 0.5 : 1,
             }}
           >
             Previous
@@ -187,16 +180,16 @@ export default function DataTable<T extends Record<string, unknown>>({
             aria-atomic="true"
             style={{ color: colors.subtext0, fontSize: '13px' }}
           >
-            Page {page + 1} of {totalPages}
+            Page {safePage + 1} of {totalPages}
           </span>
           <button
             type="button"
             onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-            disabled={page >= totalPages - 1}
+            disabled={safePage >= totalPages - 1}
             aria-label="Next page"
             style={{
               ...baseStyles.button.secondary,
-              opacity: page >= totalPages - 1 ? 0.5 : 1,
+              opacity: safePage >= totalPages - 1 ? 0.5 : 1,
             }}
           >
             Next

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,207 @@
+import { useState, useCallback, type CSSProperties } from 'react';
+import { colors, baseStyles } from '../../theme';
+
+export interface DataTableColumn<T> {
+  /** Unique key matching a property in the row data. */
+  key: string;
+  /** Display header text. */
+  header: string;
+  /** Whether this column is sortable. Default: false */
+  sortable?: boolean;
+  /** Custom cell renderer. */
+  render?: (value: unknown, row: T) => React.ReactNode;
+}
+
+export interface DataTableProps<T> {
+  /** Column definitions. */
+  columns: DataTableColumn<T>[];
+  /** Row data. */
+  data: T[];
+  /** Unique key extractor for each row. */
+  rowKey: (row: T) => string;
+  /** Rows per page. 0 = no pagination. Default: 10 */
+  pageSize?: number;
+  /** Caption for accessibility. */
+  caption?: string;
+  /** Override container style. */
+  style?: CSSProperties;
+}
+
+type SortDirection = 'asc' | 'desc';
+
+export default function DataTable<T extends Record<string, unknown>>({
+  columns,
+  data,
+  rowKey,
+  pageSize = 10,
+  caption,
+  style,
+}: DataTableProps<T>) {
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<SortDirection>('asc');
+  const [page, setPage] = useState(0);
+
+  const handleSort = useCallback(
+    (key: string) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortKey(key);
+        setSortDir('asc');
+      }
+      setPage(0);
+    },
+    [sortKey],
+  );
+
+  const sorted = [...data].sort((a, b) => {
+    if (!sortKey) return 0;
+    const aVal = a[sortKey];
+    const bVal = b[sortKey];
+    if (aVal == null && bVal == null) return 0;
+    if (aVal == null) return 1;
+    if (bVal == null) return -1;
+    const cmp = String(aVal).localeCompare(String(bVal), undefined, {
+      numeric: true,
+    });
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+
+  const paginated =
+    pageSize > 0 ? sorted.slice(page * pageSize, (page + 1) * pageSize) : sorted;
+  const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(data.length / pageSize)) : 1;
+
+  return (
+    <div style={style}>
+      <table style={baseStyles.table} role="grid" aria-label={caption}>
+        {caption && <caption style={{ ...visuallyHidden }}>{caption}</caption>}
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                style={baseStyles.th}
+                aria-sort={
+                  sortKey === col.key
+                    ? sortDir === 'asc'
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+              >
+                {col.sortable ? (
+                  <button
+                    type="button"
+                    onClick={() => handleSort(col.key)}
+                    aria-label={`Sort by ${col.header}`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: 'inherit',
+                      font: 'inherit',
+                      cursor: 'pointer',
+                      padding: 0,
+                      textTransform: 'inherit',
+                      letterSpacing: 'inherit',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                    }}
+                  >
+                    {col.header}
+                    <span aria-hidden="true">
+                      {sortKey === col.key ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+                    </span>
+                  </button>
+                ) : (
+                  col.header
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {paginated.length === 0 ? (
+            <tr>
+              <td
+                colSpan={columns.length}
+                style={{ ...baseStyles.td, textAlign: 'center', color: colors.subtext0 }}
+              >
+                No data available
+              </td>
+            </tr>
+          ) : (
+            paginated.map((row) => (
+              <tr key={rowKey(row)}>
+                {columns.map((col) => (
+                  <td key={col.key} style={baseStyles.td}>
+                    {col.render
+                      ? col.render(row[col.key], row)
+                      : String(row[col.key] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {pageSize > 0 && totalPages > 1 && (
+        <nav
+          aria-label="Table pagination"
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            gap: '8px',
+            marginTop: '12px',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            aria-label="Previous page"
+            style={{
+              ...baseStyles.button.secondary,
+              opacity: page === 0 ? 0.5 : 1,
+            }}
+          >
+            Previous
+          </button>
+          <span
+            aria-live="polite"
+            aria-atomic="true"
+            style={{ color: colors.subtext0, fontSize: '13px' }}
+          >
+            Page {page + 1} of {totalPages}
+          </span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+            aria-label="Next page"
+            style={{
+              ...baseStyles.button.secondary,
+              opacity: page >= totalPages - 1 ? 0.5 : 1,
+            }}
+          >
+            Next
+          </button>
+        </nav>
+      )}
+    </div>
+  );
+}
+
+const visuallyHidden: CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0,0,0,0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};

--- a/src/components/DataTable/index.ts
+++ b/src/components/DataTable/index.ts
@@ -1,0 +1,2 @@
+export { default as DataTable } from './DataTable';
+export type { DataTableProps, DataTableColumn } from './DataTable';

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ErrorBoundary from './ErrorBoundary';

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -80,7 +80,7 @@ describe('ErrorBoundary', () => {
     );
 
     expect(screen.getByRole('alert')).toBeInTheDocument();
-    const retryBtn = screen.getByRole('button', { name: 'Retry' });
+    const retryBtn = screen.getByRole('button', { name: 'Try Again' });
     expect(retryBtn).toBeInTheDocument();
 
     // After clicking retry, re-render with non-throwing child

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorBoundary from './ErrorBoundary';
+
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('Test error message');
+  }
+  return <div>Content rendered</div>;
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress React error boundary console.error in tests
+  const originalError = console.error;
+  beforeEach(() => {
+    console.error = vi.fn();
+  });
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>Normal content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Normal content')).toBeInTheDocument();
+  });
+
+  it('renders default error UI on error', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback ReactNode', () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback function', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <div>Error: {err.message}</div>}>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Error: Test error message')).toBeInTheDocument();
+  });
+
+  it('calls onError callback', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Test error message' }),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+  });
+
+  it('has retry button that resets error state', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    const retryBtn = screen.getByRole('button', { name: 'Retry' });
+    expect(retryBtn).toBeInTheDocument();
+
+    // After clicking retry, re-render with non-throwing child
+    rerender(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    await user.click(retryBtn);
+
+    // After retry, content should render (the rerender changed props)
+    expect(screen.getByText('Content rendered')).toBeInTheDocument();
+  });
+
+  it('has accessible alert role on error', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -74,7 +74,6 @@ export default class ErrorBoundary extends Component<
             type="button"
             onClick={this.handleRetry}
             style={baseStyles.button.primary}
-            aria-label="Retry"
           >
             Try Again
           </button>

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+import { colors, baseStyles } from '../../theme';
+
+export interface ErrorBoundaryProps {
+  /** Content to render. */
+  children: ReactNode;
+  /** Custom fallback UI. If not provided, a default error message is shown. */
+  fallback?: ReactNode | ((error: Error) => ReactNode);
+  /** Called when an error is caught. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (error) {
+      if (fallback) {
+        return typeof fallback === 'function' ? fallback(error) : fallback;
+      }
+
+      return (
+        <div
+          role="alert"
+          style={{
+            ...baseStyles.card,
+            borderColor: colors.red,
+            textAlign: 'center',
+            padding: '32px',
+          }}
+        >
+          <h2
+            style={{
+              color: colors.red,
+              fontSize: '18px',
+              fontWeight: 600,
+              margin: '0 0 8px',
+            }}
+          >
+            Something went wrong
+          </h2>
+          <p
+            style={{
+              color: colors.subtext0,
+              fontSize: '14px',
+              margin: '0 0 16px',
+            }}
+          >
+            {error.message}
+          </p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            style={baseStyles.button.primary}
+            aria-label="Retry"
+          >
+            Try Again
+          </button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { default as ErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps } from './ErrorBoundary';

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, type CSSProperties } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 import { colors } from '../theme';
 
 export type LoadingSpinnerSize = 'sm' | 'md' | 'lg';
@@ -52,7 +52,7 @@ export default function LoadingSpinner({
   style,
   color,
 }: LoadingSpinnerProps) {
-  useLayoutEffect(() => {
+  useEffect(() => {
     ensureSpinKeyframes();
   }, []);
 

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { useLayoutEffect, type CSSProperties } from 'react';
 import { colors } from '../theme';
 
 export type LoadingSpinnerSize = 'sm' | 'md' | 'lg';
@@ -52,7 +52,9 @@ export default function LoadingSpinner({
   style,
   color,
 }: LoadingSpinnerProps) {
-  ensureSpinKeyframes();
+  useLayoutEffect(() => {
+    ensureSpinKeyframes();
+  }, []);
 
   const dim = spinnerDimension[size];
   const bw = borderWidth[size];

--- a/src/components/LoadingSpinner/LoadingSpinner.test.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoadingSpinner from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders with default aria-label', () => {
+    render(<LoadingSpinner />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('renders with custom message', () => {
+    render(<LoadingSpinner message="Fetching data..." />);
+    expect(screen.getByText('Fetching data...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Fetching data...',
+    );
+  });
+
+  it('has aria-live for dynamic content', () => {
+    render(<LoadingSpinner />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('hides SVG from assistive technology', () => {
+    const { container } = render(<LoadingSpinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('accepts custom size and color', () => {
+    const { container } = render(<LoadingSpinner size={48} color="#ff0000" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '48');
+    expect(svg).toHaveAttribute('height', '48');
+  });
+});

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react';
+import { useLayoutEffect, type CSSProperties } from 'react';
 import { colors } from '../../theme';
 
 export interface LoadingSpinnerProps {
@@ -29,7 +29,9 @@ export default function LoadingSpinner({
   color = colors.blue,
   style,
 }: LoadingSpinnerProps) {
-  ensureKeyframes();
+  useLayoutEffect(() => {
+    ensureKeyframes();
+  }, []);
 
   return (
     <div

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from 'react';
+import { colors } from '../../theme';
+
+export interface LoadingSpinnerProps {
+  /** Optional loading message. */
+  message?: string;
+  /** Spinner size in pixels. Default: 32 */
+  size?: number;
+  /** Color of the spinner. Default: theme blue */
+  color?: string;
+  /** Override container style. */
+  style?: CSSProperties;
+}
+
+const keyframesId = 'wf-spinner-spin';
+
+function ensureKeyframes() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(keyframesId)) return;
+  const style = document.createElement('style');
+  style.id = keyframesId;
+  style.textContent = `@keyframes wf-spin { to { transform: rotate(360deg); } }`;
+  document.head.appendChild(style);
+}
+
+export default function LoadingSpinner({
+  message,
+  size = 32,
+  color = colors.blue,
+  style,
+}: LoadingSpinnerProps) {
+  ensureKeyframes();
+
+  return (
+    <div
+      role="status"
+      aria-label={message || 'Loading'}
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+        ...style,
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        style={{ animation: 'wf-spin 1s linear infinite' }}
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+          stroke={`${color}33`}
+          strokeWidth="3"
+        />
+        <path
+          d="M12 2a10 10 0 0 1 10 10"
+          stroke={color}
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+      </svg>
+      {message && (
+        <span style={{ color: colors.subtext0, fontSize: '14px' }}>{message}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, type CSSProperties } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 import { colors } from '../../theme';
 
 export interface LoadingSpinnerProps {
@@ -29,7 +29,7 @@ export default function LoadingSpinner({
   color = colors.blue,
   style,
 }: LoadingSpinnerProps) {
-  useLayoutEffect(() => {
+  useEffect(() => {
     ensureKeyframes();
   }, []);
 

--- a/src/components/LoadingSpinner/index.ts
+++ b/src/components/LoadingSpinner/index.ts
@@ -1,0 +1,2 @@
+export { default as LoadingSpinner } from './LoadingSpinner';
+export type { LoadingSpinnerProps } from './LoadingSpinner';

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from './Modal';
+
+// jsdom doesn't implement HTMLDialogElement.showModal/close natively
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal ||
+    function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close ||
+    function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+});
+
+describe('Modal', () => {
+  it('renders title and content when open', () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Confirm Action">
+        Are you sure?
+      </Modal>,
+    );
+    expect(screen.getByText('Confirm Action')).toBeInTheDocument();
+    expect(screen.getByText('Are you sure?')).toBeInTheDocument();
+  });
+
+  it('uses semantic dialog element', () => {
+    render(
+      <Modal open onClose={vi.fn()} title="Test">
+        Content
+      </Modal>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('has aria-labelledby linking to title', () => {
+    render(
+      <Modal open onClose={vi.fn()} title="My Dialog">
+        Content
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title');
+    expect(screen.getByText('My Dialog')).toHaveAttribute('id', 'modal-title');
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open onClose={onClose} title="Test">
+        Content
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders confirm button when onConfirm is provided', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open onClose={vi.fn()} onConfirm={onConfirm} title="Confirm">
+        Proceed?
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('shows Cancel label for confirmation variant', () => {
+    render(
+      <Modal
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        variant="confirmation"
+        title="Confirm"
+      >
+        Sure?
+      </Modal>,
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('supports custom button labels', () => {
+    render(
+      <Modal
+        open
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="Delete"
+        variant="error"
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+      >
+        Delete this?
+      </Modal>,
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeInTheDocument();
+  });
+
+  it('calls onClose on backdrop click', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Modal open onClose={onClose} title="Test">
+        Content
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    await user.click(dialog);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -44,8 +44,10 @@ describe('Modal', () => {
       </Modal>,
     );
     const dialog = screen.getByRole('dialog');
-    expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title');
-    expect(screen.getByText('My Dialog')).toHaveAttribute('id', 'modal-title');
+    const labelledById = dialog.getAttribute('aria-labelledby');
+    expect(labelledById).toBeTruthy();
+    const titleEl = screen.getByText('My Dialog');
+    expect(titleEl).toHaveAttribute('id', labelledById);
   });
 
   it('calls onClose when close button is clicked', async () => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from 'react';
+import { useEffect, useRef, useCallback, useId, type CSSProperties, type ReactNode, type MouseEvent } from 'react';
 import { colors, baseStyles } from '../../theme';
 
 export type ModalVariant = 'info' | 'confirmation' | 'error';
@@ -43,6 +43,7 @@ export default function Modal({
 }: ModalProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -57,15 +58,6 @@ export default function Modal({
     }
   }, [open]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
   // Handle native dialog cancel event (ESC key)
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -79,7 +71,7 @@ export default function Modal({
   }, [onClose]);
 
   const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
+    (e: MouseEvent<HTMLDialogElement>) => {
       if (e.target === dialogRef.current) {
         onClose();
       }
@@ -94,9 +86,8 @@ export default function Modal({
   return (
     <dialog
       ref={dialogRef}
-      onKeyDown={handleKeyDown}
       onClick={handleBackdropClick}
-      aria-labelledby="modal-title"
+      aria-labelledby={titleId}
       style={{
         backgroundColor: colors.surface0,
         color: colors.text,
@@ -117,7 +108,7 @@ export default function Modal({
           }}
         >
           <h2
-            id="modal-title"
+            id={titleId}
             style={{
               margin: 0,
               fontSize: '18px',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useCallback, type CSSProperties, type ReactNode } from 'react';
+import { colors, baseStyles } from '../../theme';
+
+export type ModalVariant = 'info' | 'confirmation' | 'error';
+
+export interface ModalProps {
+  /** Whether the modal is open. */
+  open: boolean;
+  /** Called when the modal should close. */
+  onClose: () => void;
+  /** Modal title. */
+  title: string;
+  /** Modal content. */
+  children: ReactNode;
+  /** Variant determines styling. Default: 'info' */
+  variant?: ModalVariant;
+  /** Text for the confirm/primary button. Default: 'OK' */
+  confirmLabel?: string;
+  /** Called when confirm button is clicked. If omitted, only a close button is shown. */
+  onConfirm?: () => void;
+  /** Text for the cancel/close button. Default: 'Cancel' for confirmation, 'Close' otherwise */
+  cancelLabel?: string;
+  /** Override container style. */
+  style?: CSSProperties;
+}
+
+const variantColors: Record<ModalVariant, string> = {
+  info: colors.blue,
+  confirmation: colors.yellow,
+  error: colors.red,
+};
+
+export default function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  variant = 'info',
+  confirmLabel = 'OK',
+  onConfirm,
+  cancelLabel,
+  style,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      dialog.showModal();
+    } else if (!open && dialog.open) {
+      dialog.close();
+      previousFocusRef.current?.focus();
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  // Handle native dialog cancel event (ESC key)
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const handler = (e: Event) => {
+      e.preventDefault();
+      onClose();
+    };
+    dialog.addEventListener('cancel', handler);
+    return () => dialog.removeEventListener('cancel', handler);
+  }, [onClose]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === dialogRef.current) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const defaultCancelLabel =
+    cancelLabel ?? (variant === 'confirmation' ? 'Cancel' : 'Close');
+  const accentColor = variantColors[variant];
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onKeyDown={handleKeyDown}
+      onClick={handleBackdropClick}
+      aria-labelledby="modal-title"
+      style={{
+        backgroundColor: colors.surface0,
+        color: colors.text,
+        border: `1px solid ${colors.surface1}`,
+        borderRadius: '12px',
+        padding: 0,
+        maxWidth: '480px',
+        width: '100%',
+        ...style,
+      }}
+    >
+      <div style={{ padding: '24px' }}>
+        <header
+          style={{
+            marginBottom: '16px',
+            borderBottom: `2px solid ${accentColor}`,
+            paddingBottom: '12px',
+          }}
+        >
+          <h2
+            id="modal-title"
+            style={{
+              margin: 0,
+              fontSize: '18px',
+              fontWeight: 600,
+              color: accentColor,
+            }}
+          >
+            {title}
+          </h2>
+        </header>
+
+        <div style={{ marginBottom: '24px', lineHeight: 1.5 }}>{children}</div>
+
+        <footer
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '8px',
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={baseStyles.button.secondary}
+          >
+            {defaultCancelLabel}
+          </button>
+          {onConfirm && (
+            <button
+              type="button"
+              onClick={onConfirm}
+              style={
+                variant === 'error'
+                  ? baseStyles.button.danger
+                  : baseStyles.button.primary
+              }
+            >
+              {confirmLabel}
+            </button>
+          )}
+        </footer>
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,2 @@
+export { default as Modal } from './Modal';
+export type { ModalProps, ModalVariant } from './Modal';

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusBadge from './StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders with status text', () => {
+    render(<StatusBadge status="running" />);
+    expect(screen.getByRole('status')).toHaveTextContent('Running');
+  });
+
+  it('renders custom label', () => {
+    render(<StatusBadge status="failed" label="Deploy Failed" />);
+    expect(screen.getByRole('status')).toHaveTextContent('Deploy Failed');
+  });
+
+  it('has accessible aria-label', () => {
+    render(<StatusBadge status="completed" />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Status: Completed',
+    );
+  });
+
+  it('uses custom label in aria-label', () => {
+    render(<StatusBadge status="error" label="Critical Error" />);
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Status: Critical Error',
+    );
+  });
+
+  it('renders different sizes', () => {
+    const { rerender } = render(<StatusBadge status="idle" size="sm" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    rerender(<StatusBadge status="idle" size="lg" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('hides decorative dot from assistive technology', () => {
+    const { container } = render(<StatusBadge status="active" />);
+    const dot = container.querySelector('[aria-hidden="true"]');
+    expect(dot).toBeInTheDocument();
+  });
+});

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -1,0 +1,76 @@
+import type { CSSProperties } from 'react';
+import { colors, statusColors } from '../../theme';
+
+export type StatusType =
+  | 'idle'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'error'
+  | 'pending'
+  | 'canceled'
+  | 'active';
+
+export interface StatusBadgeProps {
+  /** The status to display. */
+  status: StatusType;
+  /** Optional label override. Defaults to the status string. */
+  label?: string;
+  /** Optional size variant. */
+  size?: 'sm' | 'md' | 'lg';
+  /** Override container style. */
+  style?: CSSProperties;
+}
+
+const sizeStyles: Record<string, CSSProperties> = {
+  sm: { fontSize: '11px', padding: '2px 8px' },
+  md: { fontSize: '12px', padding: '4px 10px' },
+  lg: { fontSize: '14px', padding: '6px 14px' },
+};
+
+const dotSizes: Record<string, number> = {
+  sm: 6,
+  md: 8,
+  lg: 10,
+};
+
+export default function StatusBadge({
+  status,
+  label,
+  size = 'md',
+  style,
+}: StatusBadgeProps) {
+  const color = statusColors[status] ?? colors.overlay0;
+  const displayLabel = label ?? status.charAt(0).toUpperCase() + status.slice(1);
+  const dotSize = dotSizes[size];
+
+  return (
+    <span
+      role="status"
+      aria-label={`Status: ${displayLabel}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        borderRadius: '9999px',
+        fontWeight: 500,
+        color,
+        backgroundColor: `${color}22`,
+        ...sizeStyles[size],
+        ...style,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: dotSize,
+          height: dotSize,
+          borderRadius: '50%',
+          backgroundColor: color,
+          flexShrink: 0,
+        }}
+      />
+      {displayLabel}
+    </span>
+  );
+}

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -17,18 +17,20 @@ export interface StatusBadgeProps {
   /** Optional label override. Defaults to the status string. */
   label?: string;
   /** Optional size variant. */
-  size?: 'sm' | 'md' | 'lg';
+  size?: StatusBadgeSize;
   /** Override container style. */
   style?: CSSProperties;
 }
 
-const sizeStyles: Record<string, CSSProperties> = {
+type StatusBadgeSize = 'sm' | 'md' | 'lg';
+
+const sizeStyles: Record<StatusBadgeSize, CSSProperties> = {
   sm: { fontSize: '11px', padding: '2px 8px' },
   md: { fontSize: '12px', padding: '4px 10px' },
   lg: { fontSize: '14px', padding: '6px 14px' },
 };
 
-const dotSizes: Record<string, number> = {
+const dotSizes: Record<StatusBadgeSize, number> = {
   sm: 6,
   md: 8,
   lg: 10,

--- a/src/components/StatusBadge/index.ts
+++ b/src/components/StatusBadge/index.ts
@@ -1,0 +1,2 @@
+export { default as StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps, StatusType } from './StatusBadge';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,14 @@
+export { StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps, StatusType } from './StatusBadge';
+
+export { DataTable } from './DataTable';
+export type { DataTableProps, DataTableColumn } from './DataTable';
+
+export { Modal } from './Modal';
+export type { ModalProps, ModalVariant } from './Modal';
+
+export { LoadingSpinner } from './LoadingSpinner';
+export type { LoadingSpinnerProps } from './LoadingSpinner';
+
+export { ErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps } from './ErrorBoundary';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,22 @@ export type { SSEConfig } from './sse';
 
 // Theme
 export { colors, statusColors, baseStyles } from './theme';
+
+// Components
+export {
+  StatusBadge,
+  DataTable,
+  Modal,
+  LoadingSpinner,
+  ErrorBoundary,
+} from './components';
+export type {
+  StatusBadgeProps,
+  StatusType,
+  DataTableProps,
+  DataTableColumn,
+  ModalProps,
+  ModalVariant,
+  LoadingSpinnerProps,
+  ErrorBoundaryProps,
+} from './components';


### PR DESCRIPTION
## Summary

Adds 5 new shared React components with full TypeScript types, unit tests, and WCAG accessibility support. Also adds accessibility improvements to the existing LoginPage component.

### New Components

| Component | Description |
|-----------|-------------|
| **StatusBadge** | Color-coded workflow status indicator (idle, running, completed, failed, error, etc.) using theme `statusColors` |
| **DataTable** | Sortable, paginated data table with generic typing, custom cell renderers, and accessible sort/pagination controls |
| **Modal** | Dialog component using native `<dialog>` element with info/confirmation/error variants, focus management, and backdrop click |
| **LoadingSpinner** | SVG loading spinner with optional message, `aria-live` region for dynamic updates |
| **ErrorBoundary** | React error boundary with default error UI, custom fallback support, retry button, and `onError` callback |

### Accessibility Improvements (all components)

- Semantic HTML: `<main>`, `<form>`, `<dialog>`, `<table>`, `<nav>`, `<header>`, `<footer>`
- ARIA attributes: `role`, `aria-label`, `aria-labelledby`, `aria-sort`, `aria-live`, `aria-busy`, `aria-required`, `aria-hidden`
- Keyboard navigation: focus management in Modal, tab-accessible sort buttons and pagination
- Labels associated with inputs via `htmlFor`/`id`
- Error messages use `role="alert"` with `aria-live="assertive"`

### LoginPage a11y updates
- Wrapped in `<main>` landmark
- Form has `aria-label="Sign in"`
- Labels linked to inputs with `htmlFor`
- Inputs have `aria-required`
- Submit button has `aria-busy` during loading
- Error div has `role="alert"` and `aria-live="assertive"`

### Tests
- 73 tests passing (was 30)
- Every new component has tests for rendering, props, interactions, and accessibility
- Build and lint pass cleanly

Closes #3, Closes #4