### PR TITLE
feat: expand shared component library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -497,6 +498,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -537,6 +539,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1719,8 +1722,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1805,6 +1807,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1815,6 +1818,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1864,6 +1868,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2252,6 +2257,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2302,7 +2308,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2411,6 +2416,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2647,8 +2653,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2748,6 +2753,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3265,6 +3271,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -3410,7 +3417,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3622,6 +3628,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3674,7 +3681,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3690,7 +3696,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3714,6 +3719,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3724,6 +3730,7 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3736,8 +3743,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4080,6 +4086,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4169,6 +4176,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4450,6 +4458,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "types": "./dist/theme/index.d.ts",
       "import": "./dist/theme/index.js",
       "require": "./dist/theme/index.cjs"
+    },
+    "./components": {
+      "types": "./dist/components/index.d.ts",
+      "import": "./dist/components/index.js",
+      "require": "./dist/components/index.cjs"
     }
   },
   "files": [

--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DataTable, { type DataTableColumn } from './DataTable';
+
+interface Row {
+  id: number;
+  name: string;
+  status: string;
+}
+
+const columns: DataTableColumn<Row>[] = [
+  { label: 'ID', key: 'id', sortable: true },
+  { label: 'Name', key: 'name', sortable: true },
+  { label: 'Status', key: 'status' },
+];
+
+const makeRows = (count: number): Row[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `Item ${i + 1}`,
+    status: i % 2 === 0 ? 'active' : 'stopped',
+  }));
+
+describe('DataTable', () => {
+  it('renders column headers', () => {
+    render(<DataTable columns={columns} data={[]} />);
+    expect(screen.getByText('ID')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('renders rows', () => {
+    const data = makeRows(3);
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+
+  it('shows empty message when data is empty', () => {
+    render(<DataTable columns={columns} data={[]} emptyMessage="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('shows default empty message', () => {
+    render(<DataTable columns={columns} data={[]} />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('paginates data and shows pagination controls', () => {
+    const data = makeRows(15);
+    render(<DataTable columns={columns} data={data} pageSize={5} />);
+    // First page: items 1-5
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.queryByText('Item 6')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+  });
+
+  it('navigates to next page', async () => {
+    const user = userEvent.setup();
+    const data = makeRows(12);
+    render(<DataTable columns={columns} data={data} pageSize={5} />);
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(screen.getByText('Item 6')).toBeInTheDocument();
+    expect(screen.queryByText('Item 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+  });
+
+  it('navigates to previous page', async () => {
+    const user = userEvent.setup();
+    const data = makeRows(12);
+    render(<DataTable columns={columns} data={data} pageSize={5} />);
+
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    await user.click(screen.getByRole('button', { name: 'Previous page' }));
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+  });
+
+  it('does not show pagination for single page', () => {
+    const data = makeRows(5);
+    render(<DataTable columns={columns} data={data} pageSize={10} />);
+    expect(screen.queryByRole('button', { name: 'Next page' })).not.toBeInTheDocument();
+  });
+
+  it('calls onSort when sortable column header is clicked', async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(<DataTable columns={columns} data={makeRows(3)} onSort={onSort} />);
+
+    await user.click(screen.getByText('ID'));
+    expect(onSort).toHaveBeenCalledWith({ key: 'id', direction: 'asc' });
+  });
+
+  it('toggles sort direction on second click', async () => {
+    const user = userEvent.setup();
+    const onSort = vi.fn();
+    render(<DataTable columns={columns} data={makeRows(3)} onSort={onSort} />);
+
+    await user.click(screen.getByText('ID'));
+    await user.click(screen.getByText('ID'));
+    expect(onSort).toHaveBeenLastCalledWith({ key: 'id', direction: 'desc' });
+  });
+
+  it('renders custom cell via render prop', () => {
+    const customColumns: DataTableColumn<Row>[] = [
+      {
+        label: 'Name',
+        key: 'name',
+        render: (value) => <strong>{String(value)}-custom</strong>,
+      },
+    ];
+    render(<DataTable columns={customColumns} data={makeRows(1)} />);
+    expect(screen.getByText('Item 1-custom')).toBeInTheDocument();
+  });
+
+  it('calls onPageChange when page changes', async () => {
+    const user = userEvent.setup();
+    const onPageChange = vi.fn();
+    render(
+      <DataTable
+        columns={columns}
+        data={makeRows(15)}
+        pageSize={5}
+        onPageChange={onPageChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Next page' }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -73,7 +73,14 @@ export default function DataTable<T extends Record<string, unknown>>({
   const [currentPage, setCurrentPage] = useState(1);
   const [sortState, setSortState] = useState<SortState<T> | null>(null);
 
-  const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
+  function getRowKey(row: T, absoluteIdx: number): string | number {
+    if (rowKey) return rowKey(row, absoluteIdx);
+    const id = (row as Record<string, unknown>).id;
+    return (typeof id === 'string' || typeof id === 'number') ? id : absoluteIdx;
+  }
+
+  const safePageSize = Math.max(1, pageSize);
+  const totalPages = Math.max(1, Math.ceil(data.length / safePageSize));
   const safePage = Math.min(currentPage, totalPages);
 
   // Client-side sort when no external onSort handler
@@ -93,7 +100,7 @@ export default function DataTable<T extends Record<string, unknown>>({
         })
       : data;
 
-  const pageData = sortedData.slice((safePage - 1) * pageSize, safePage * pageSize);
+  const pageData = sortedData.slice((safePage - 1) * safePageSize, safePage * safePageSize);
 
   function handleSort(col: DataTableColumn<T>) {
     if (!col.sortable) return;
@@ -187,7 +194,7 @@ export default function DataTable<T extends Record<string, unknown>>({
             ) : (
               pageData.map((row, idx) => (
                 <tr
-                  key={rowKey ? rowKey(row, (safePage - 1) * pageSize + idx) : (safePage - 1) * pageSize + idx}
+                  key={getRowKey(row, (safePage - 1) * safePageSize + idx)}
                 >
                   {columns.map((col) => (
                     <td key={col.key} style={{ ...baseStyles.td, ...col.cellStyle }}>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, type CSSProperties } from 'react';
+import { useState, type CSSProperties, type ReactNode } from 'react';
 import { colors, baseStyles } from '../theme';
 
 export interface DataTableColumn<T> {
@@ -9,7 +9,7 @@ export interface DataTableColumn<T> {
   /** Whether this column is sortable. Default: false */
   sortable?: boolean;
   /** Optional custom cell renderer. */
-  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  render?: (value: T[keyof T], row: T) => ReactNode;
   /** Optional column header style override. */
   headerStyle?: CSSProperties;
   /** Optional cell style override. */
@@ -114,6 +114,7 @@ export default function DataTable<T extends Record<string, unknown>>({
     fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
     ...style,
   };
+  const thPadding = baseStyles.th.padding;
 
   return (
     <div style={containerStyle}>
@@ -126,10 +127,9 @@ export default function DataTable<T extends Record<string, unknown>>({
                   key={col.key}
                   style={{
                     ...baseStyles.th,
-                    cursor: col.sortable ? 'pointer' : 'default',
+                    padding: 0,
                     ...col.headerStyle,
                   }}
-                  onClick={() => handleSort(col)}
                   aria-sort={
                     sortState?.key === col.key
                       ? sortState.direction === 'asc'
@@ -138,12 +138,32 @@ export default function DataTable<T extends Record<string, unknown>>({
                       : undefined
                   }
                 >
-                  {col.label}
-                  {col.sortable && (
-                    <SortIcon
-                      direction={sortState?.key === col.key ? sortState.direction : undefined}
-                      active={sortState?.key === col.key}
-                    />
+                  {col.sortable ? (
+                    <button
+                      onClick={() => handleSort(col)}
+                      style={{
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                        padding: thPadding,
+                        width: '100%',
+                        textAlign: 'left',
+                        font: 'inherit',
+                        color: 'inherit',
+                        display: 'flex',
+                        alignItems: 'center',
+                      }}
+                    >
+                      {col.label}
+                      <SortIcon
+                        direction={sortState?.key === col.key ? sortState.direction : undefined}
+                        active={sortState?.key === col.key}
+                      />
+                    </button>
+                  ) : (
+                    <span style={{ display: 'block', padding: thPadding }}>
+                      {col.label}
+                    </span>
                   )}
                 </th>
               ))}
@@ -173,7 +193,7 @@ export default function DataTable<T extends Record<string, unknown>>({
                     <td key={col.key} style={{ ...baseStyles.td, ...col.cellStyle }}>
                       {col.render
                         ? col.render(row[col.key], row)
-                        : (row[col.key] as React.ReactNode)}
+                        : (row[col.key] as ReactNode)}
                     </td>
                   ))}
                 </tr>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,233 @@
+import { useState, type CSSProperties } from 'react';
+import { colors, baseStyles } from '../theme';
+
+export interface DataTableColumn<T> {
+  /** Column header label. */
+  label: string;
+  /** Key of the row object to render (also used as React key). */
+  key: keyof T & string;
+  /** Whether this column is sortable. Default: false */
+  sortable?: boolean;
+  /** Optional custom cell renderer. */
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+  /** Optional column header style override. */
+  headerStyle?: CSSProperties;
+  /** Optional cell style override. */
+  cellStyle?: CSSProperties;
+}
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortState<T> {
+  key: keyof T & string;
+  direction: SortDirection;
+}
+
+export interface DataTableProps<T extends Record<string, unknown>> {
+  /** Column definitions. */
+  columns: DataTableColumn<T>[];
+  /** Row data. */
+  data: T[];
+  /** Number of rows per page. Default: 10 */
+  pageSize?: number;
+  /** Called when user clicks a sortable column header. */
+  onSort?: (sort: SortState<T>) => void;
+  /** Called when page changes. */
+  onPageChange?: (page: number) => void;
+  /** Row key extractor. Defaults to row index. */
+  rowKey?: (row: T, index: number) => string | number;
+  /** Empty state message. Default: 'No data' */
+  emptyMessage?: string;
+  /** Override table container style. */
+  style?: CSSProperties;
+}
+
+function SortIcon({ direction, active }: { direction?: SortDirection; active: boolean }) {
+  const color = active ? colors.blue : colors.overlay0;
+  return (
+    <span
+      style={{
+        marginLeft: '4px',
+        display: 'inline-block',
+        fontSize: '10px',
+        color,
+        userSelect: 'none',
+      }}
+      aria-hidden="true"
+    >
+      {direction === 'asc' ? '▲' : direction === 'desc' ? '▼' : '⇅'}
+    </span>
+  );
+}
+
+export default function DataTable<T extends Record<string, unknown>>({
+  columns,
+  data,
+  pageSize = 10,
+  onSort,
+  onPageChange,
+  rowKey,
+  emptyMessage = 'No data',
+  style,
+}: DataTableProps<T>) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortState, setSortState] = useState<SortState<T> | null>(null);
+
+  const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
+  const safePage = Math.min(currentPage, totalPages);
+
+  // Client-side sort when no external onSort handler
+  const sortedData = onSort
+    ? data
+    : sortState
+      ? [...data].sort((a, b) => {
+          const av = a[sortState.key];
+          const bv = b[sortState.key];
+          const cmp =
+            av == null ? -1
+            : bv == null ? 1
+            : typeof av === 'number' && typeof bv === 'number'
+              ? av - bv
+              : String(av).localeCompare(String(bv));
+          return sortState.direction === 'asc' ? cmp : -cmp;
+        })
+      : data;
+
+  const pageData = sortedData.slice((safePage - 1) * pageSize, safePage * pageSize);
+
+  function handleSort(col: DataTableColumn<T>) {
+    if (!col.sortable) return;
+    const newDirection: SortDirection =
+      sortState?.key === col.key && sortState.direction === 'asc' ? 'desc' : 'asc';
+    const newSort: SortState<T> = { key: col.key, direction: newDirection };
+    setSortState(newSort);
+    onSort?.(newSort);
+  }
+
+  function handlePage(page: number) {
+    const p = Math.max(1, Math.min(page, totalPages));
+    setCurrentPage(p);
+    onPageChange?.(p);
+  }
+
+  const containerStyle: CSSProperties = {
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    ...style,
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={{ overflowX: 'auto' }}>
+        <table style={baseStyles.table}>
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  style={{
+                    ...baseStyles.th,
+                    cursor: col.sortable ? 'pointer' : 'default',
+                    ...col.headerStyle,
+                  }}
+                  onClick={() => handleSort(col)}
+                  aria-sort={
+                    sortState?.key === col.key
+                      ? sortState.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : undefined
+                  }
+                >
+                  {col.label}
+                  {col.sortable && (
+                    <SortIcon
+                      direction={sortState?.key === col.key ? sortState.direction : undefined}
+                      active={sortState?.key === col.key}
+                    />
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {pageData.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  style={{
+                    ...baseStyles.td,
+                    textAlign: 'center',
+                    color: colors.overlay0,
+                    padding: '32px 12px',
+                  }}
+                >
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              pageData.map((row, idx) => (
+                <tr
+                  key={rowKey ? rowKey(row, (safePage - 1) * pageSize + idx) : (safePage - 1) * pageSize + idx}
+                >
+                  {columns.map((col) => (
+                    <td key={col.key} style={{ ...baseStyles.td, ...col.cellStyle }}>
+                      {col.render
+                        ? col.render(row[col.key], row)
+                        : (row[col.key] as React.ReactNode)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            gap: '8px',
+            padding: '12px 4px 4px',
+            fontSize: '13px',
+            color: colors.subtext0,
+          }}
+        >
+          <span>
+            Page {safePage} of {totalPages}
+          </span>
+          <button
+            onClick={() => handlePage(safePage - 1)}
+            disabled={safePage <= 1}
+            style={{
+              ...baseStyles.button.secondary,
+              padding: '4px 10px',
+              fontSize: '13px',
+              opacity: safePage <= 1 ? 0.4 : 1,
+              cursor: safePage <= 1 ? 'not-allowed' : 'pointer',
+            }}
+            aria-label="Previous page"
+          >
+            ‹
+          </button>
+          <button
+            onClick={() => handlePage(safePage + 1)}
+            disabled={safePage >= totalPages}
+            style={{
+              ...baseStyles.button.secondary,
+              padding: '4px 10px',
+              fontSize: '13px',
+              opacity: safePage >= totalPages ? 0.4 : 1,
+              cursor: safePage >= totalPages ? 'not-allowed' : 'pointer',
+            }}
+            aria-label="Next page"
+          >
+            ›
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ErrorBoundary from './ErrorBoundary';

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ErrorBoundary from './ErrorBoundary';
+
+/** Component that throws on render when `shouldThrow` is true. */
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Boom!');
+  return <div>Safe content</div>;
+}
+
+// Suppress the expected console errors from React's error boundary
+const consoleError = console.error;
+beforeEach(() => {
+  console.error = vi.fn();
+});
+afterEach(() => {
+  console.error = consoleError;
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Safe content')).toBeInTheDocument();
+  });
+
+  it('shows default fallback when child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Boom!')).toBeInTheDocument();
+  });
+
+  it('renders custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <div>Custom: {err.message}</div>}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Custom: Boom!')).toBeInTheDocument();
+  });
+
+  it('calls onError callback when an error is caught', () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0][0].message).toBe('Boom!');
+  });
+
+  it('resets error state on "Try again" click', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    // Click "Try again" — resets error boundary state, re-renders children.
+    // Child still throws so the boundary catches again and shows fallback.
+    const tryAgain = screen.getByRole('button', { name: 'Try again' });
+    await user.click(tryAgain);
+    // After reset the boundary re-renders — child still throws, so we still see the fallback
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('reset via custom fallback clears error', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ErrorBoundary
+        fallback={(err, reset) => (
+          <div>
+            <span>{err.message}</span>
+            <button onClick={reset}>Reset</button>
+          </div>
+        )}
+      >
+        <Bomb shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Boom!')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+    // After reset, child still throws so fallback shown again — boundary works correctly
+    expect(screen.getByText('Boom!')).toBeInTheDocument();
+  });
+});

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -36,7 +36,7 @@ describe('ErrorBoundary', () => {
     );
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('Something went wrong')).toBeInTheDocument();
-    expect(screen.getByText('Boom!')).toBeInTheDocument();
+    expect(screen.getByText(/An unexpected error occurred/)).toBeInTheDocument();
   });
 
   it('renders custom fallback when provided', () => {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,118 @@
+import { Component, type ReactNode, type ErrorInfo, type CSSProperties } from 'react';
+import { colors } from '../theme';
+
+export interface ErrorBoundaryProps {
+  /** Content to render when there is no error. */
+  children: ReactNode;
+  /** Custom fallback UI. Receives the caught error. */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  /** Called when an error is caught. */
+  onError?: (error: Error, info: ErrorInfo) => void;
+  /** Override error card style. */
+  style?: CSSProperties;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/** Default error display shown when no fallback prop is provided. */
+function DefaultErrorFallback({
+  error,
+  onReset,
+  style,
+}: {
+  error: Error;
+  onReset: () => void;
+  style?: CSSProperties;
+}) {
+  const cardStyle: CSSProperties = {
+    backgroundColor: `${colors.red}11`,
+    border: `1px solid ${colors.red}55`,
+    borderRadius: '8px',
+    padding: '20px 24px',
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    maxWidth: '600px',
+    ...style,
+  };
+
+  return (
+    <div role="alert" style={cardStyle}>
+      <p
+        style={{
+          margin: '0 0 6px',
+          fontWeight: '600',
+          fontSize: '15px',
+          color: colors.red,
+        }}
+      >
+        Something went wrong
+      </p>
+      <p
+        style={{
+          margin: '0 0 16px',
+          fontSize: '13px',
+          color: colors.subtext0,
+          fontFamily: 'monospace',
+          wordBreak: 'break-word',
+        }}
+      >
+        {error.message}
+      </p>
+      <button
+        onClick={onReset}
+        style={{
+          backgroundColor: colors.surface1,
+          color: colors.text,
+          border: 'none',
+          borderRadius: '6px',
+          padding: '6px 14px',
+          fontSize: '13px',
+          cursor: 'pointer',
+        }}
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+/**
+ * React error boundary that catches render errors in the component tree.
+ * Must be a class component — hooks cannot catch render errors.
+ */
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) {
+        return this.props.fallback(error, this.reset);
+      }
+      return (
+        <DefaultErrorFallback
+          error={error}
+          onReset={this.reset}
+          style={this.props.style}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -18,11 +18,9 @@ interface ErrorBoundaryState {
 
 /** Default error display shown when no fallback prop is provided. */
 function DefaultErrorFallback({
-  error,
   onReset,
   style,
 }: {
-  error: Error;
   onReset: () => void;
   style?: CSSProperties;
 }) {
@@ -57,7 +55,7 @@ function DefaultErrorFallback({
           wordBreak: 'break-word',
         }}
       >
-        {error.message}
+        An unexpected error occurred. Please try again or contact support if the problem persists.
       </p>
       <button
         onClick={onReset}
@@ -107,7 +105,6 @@ export default class ErrorBoundary extends Component<
       }
       return (
         <DefaultErrorFallback
-          error={error}
           onReset={this.reset}
           style={this.props.style}
         />

--- a/src/components/LoadingSpinner.test.tsx
+++ b/src/components/LoadingSpinner.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LoadingSpinner from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders with default aria-label', () => {
+    render(<LoadingSpinner />);
+    expect(screen.getByRole('status', { name: 'Loading' })).toBeInTheDocument();
+  });
+
+  it('renders with custom message', () => {
+    render(<LoadingSpinner message="Please wait..." />);
+    expect(screen.getByText('Please wait...')).toBeInTheDocument();
+  });
+
+  it('uses message as aria-label when provided', () => {
+    render(<LoadingSpinner message="Saving" />);
+    expect(screen.getByRole('status', { name: 'Saving' })).toBeInTheDocument();
+  });
+
+  it('renders without message (no text node)', () => {
+    const { container } = render(<LoadingSpinner />);
+    // Only the spinner ring, no extra text
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBe(0);
+  });
+
+  it('renders sm size', () => {
+    const { container } = render(<LoadingSpinner size="sm" />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('renders lg size', () => {
+    const { container } = render(<LoadingSpinner size="lg" />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('applies custom style', () => {
+    const { container } = render(
+      <LoadingSpinner style={{ margin: '20px' }} />,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.margin).toBe('20px');
+  });
+
+  it('applies custom color to spinner', () => {
+    const { container } = render(<LoadingSpinner color="#ff0000" />);
+    // The DOM structure is: container > div[role=status] > div(ring)
+    // Select the ring by querying inside the status element.
+    // jsdom normalises borderTopColor into the border-color shorthand as rgb().
+    const status = container.querySelector('[role="status"]') as HTMLElement;
+    const ring = status.querySelector('div') as HTMLElement;
+    const styleAttr = ring.getAttribute('style') ?? '';
+    expect(styleAttr).toContain('rgb(255, 0, 0)');
+  });
+});

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,100 @@
+import type { CSSProperties } from 'react';
+import { colors } from '../theme';
+
+export type LoadingSpinnerSize = 'sm' | 'md' | 'lg';
+
+export interface LoadingSpinnerProps {
+  /** Spinner size. Default: 'md' */
+  size?: LoadingSpinnerSize;
+  /** Optional message displayed below the spinner. */
+  message?: string;
+  /** Override wrapper style. */
+  style?: CSSProperties;
+  /** Color of the spinning arc. Default: colors.blue */
+  color?: string;
+}
+
+const spinnerDimension: Record<LoadingSpinnerSize, number> = {
+  sm: 16,
+  md: 32,
+  lg: 48,
+};
+
+const borderWidth: Record<LoadingSpinnerSize, number> = {
+  sm: 2,
+  md: 3,
+  lg: 4,
+};
+
+const messageFontSize: Record<LoadingSpinnerSize, string> = {
+  sm: '11px',
+  md: '13px',
+  lg: '15px',
+};
+
+/** Inject the spin keyframes once. */
+let spinInjected = false;
+function ensureSpinKeyframes() {
+  if (spinInjected || typeof document === 'undefined') return;
+  spinInjected = true;
+  const style = document.createElement('style');
+  style.textContent = `
+    @keyframes workflow-ui-spin {
+      to { transform: rotate(360deg); }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export default function LoadingSpinner({
+  size = 'md',
+  message,
+  style,
+  color,
+}: LoadingSpinnerProps) {
+  ensureSpinKeyframes();
+
+  const dim = spinnerDimension[size];
+  const bw = borderWidth[size];
+  const spinColor = color ?? colors.blue;
+
+  const wrapperStyle: CSSProperties = {
+    display: 'inline-flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '10px',
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    ...style,
+  };
+
+  const ringStyle: CSSProperties = {
+    width: dim,
+    height: dim,
+    borderRadius: '50%',
+    border: `${bw}px solid ${colors.surface1}`,
+    borderTopColor: spinColor,
+    animation: 'workflow-ui-spin 0.75s linear infinite',
+    flexShrink: 0,
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label={message ?? 'Loading'}
+      style={wrapperStyle}
+    >
+      <div style={ringStyle} />
+      {message && (
+        <span
+          style={{
+            color: colors.subtext0,
+            fontSize: messageFontSize[size],
+          }}
+        >
+          {message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/Modal.test.tsx
+++ b/src/components/Modal.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from './Modal';
+
+describe('Modal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <Modal open={false} onClose={vi.fn()} title="Test">
+        <p>Content</p>
+      </Modal>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders dialog when open', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="Hello">
+        <p>Modal body</p>
+      </Modal>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Modal body')).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose} title="Close me">
+        <p>content</p>
+      </Modal>,
+    );
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when backdrop is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { container } = render(
+      <Modal open={true} onClose={onClose} title="Backdrop">
+        <p>content</p>
+      </Modal>,
+    );
+    // Click the overlay (parent of dialog)
+    const overlay = container.ownerDocument.querySelector('[role="presentation"]');
+    if (overlay) {
+      await user.click(overlay);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('calls onClose on Escape key', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose} title="Escape">
+        <p>content</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    dialog.focus();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders action buttons', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <Modal
+        open={true}
+        onClose={vi.fn()}
+        title="Confirm"
+        actions={[
+          { label: 'Cancel', onClick: onCancel, variant: 'secondary' },
+          { label: 'Confirm', onClick: onConfirm, variant: 'primary' },
+        ]}
+      >
+        <p>Are you sure?</p>
+      </Modal>,
+    );
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders without title', () => {
+    render(
+      <Modal open={true} onClose={vi.fn()}>
+        <p>No title content</p>
+      </Modal>,
+    );
+    expect(screen.getByText('No title content')).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('disabled action button cannot be clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <Modal
+        open={true}
+        onClose={vi.fn()}
+        title="Disabled"
+        actions={[{ label: 'Blocked', onClick, disabled: true }]}
+      >
+        <p>content</p>
+      </Modal>,
+    );
+    const btn = screen.getByRole('button', { name: 'Blocked' });
+    expect(btn).toBeDisabled();
+    await user.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -49,13 +49,18 @@ export default function Modal({
   style,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
   const titleId = useId();
 
-  // Focus trap: focus the dialog on open.
+  // Focus trap: focus the dialog on open, restore focus on close/unmount.
   useEffect(() => {
-    if (open) {
-      dialogRef.current?.focus();
-    }
+    if (!open) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      previouslyFocusedRef.current?.focus();
+      previouslyFocusedRef.current = null;
+    };
   }, [open]);
 
   // Prevent body scroll while open.

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useId,
   useRef,
   type CSSProperties,
   type ReactNode,
@@ -9,6 +10,8 @@ import { createPortal } from 'react-dom';
 import { colors, baseStyles } from '../theme';
 
 export interface ModalAction {
+  /** Stable unique identifier for this action button (used as React key). */
+  id?: string;
   /** Button label. */
   label: string;
   /** Click handler. */
@@ -46,6 +49,7 @@ export default function Modal({
   style,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
 
   // Focus trap: focus the dialog on open.
   useEffect(() => {
@@ -136,7 +140,7 @@ export default function Modal({
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby={title ? 'modal-title' : undefined}
+        aria-labelledby={title ? titleId : undefined}
         tabIndex={-1}
         style={dialogStyle}
         onClick={(e) => e.stopPropagation()}
@@ -145,7 +149,7 @@ export default function Modal({
         {(title != null) && (
           <div style={headerStyle}>
             <h2
-              id="modal-title"
+              id={titleId}
               style={{
                 margin: 0,
                 fontSize: '18px',
@@ -179,9 +183,9 @@ export default function Modal({
 
         {actions && actions.length > 0 && (
           <div style={footerStyle}>
-            {actions.map((action) => (
+            {actions.map((action, idx) => (
               <button
-                key={action.label}
+                key={action.id ?? idx}
                 onClick={action.onClick}
                 disabled={action.disabled}
                 style={{
@@ -198,6 +202,10 @@ export default function Modal({
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
 
   return createPortal(modal, document.body);
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,203 @@
+import {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type ReactNode,
+  type KeyboardEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { colors, baseStyles } from '../theme';
+
+export interface ModalAction {
+  /** Button label. */
+  label: string;
+  /** Click handler. */
+  onClick: () => void;
+  /** Button variant. Default: 'secondary' */
+  variant?: 'primary' | 'secondary' | 'danger';
+  /** Disable the button. */
+  disabled?: boolean;
+}
+
+export interface ModalProps {
+  /** Whether the modal is visible. */
+  open: boolean;
+  /** Called when the modal should close (backdrop click or Escape key). */
+  onClose: () => void;
+  /** Modal title. */
+  title?: string;
+  /** Modal body content. */
+  children?: ReactNode;
+  /** Action buttons rendered in the footer. */
+  actions?: ModalAction[];
+  /** Modal width. Default: '480px' */
+  width?: string;
+  /** Override modal container style. */
+  style?: CSSProperties;
+}
+
+export default function Modal({
+  open,
+  onClose,
+  title,
+  children,
+  actions,
+  width = '480px',
+  style,
+}: ModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus trap: focus the dialog on open.
+  useEffect(() => {
+    if (open) {
+      dialogRef.current?.focus();
+    }
+  }, [open]);
+
+  // Prevent body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  }
+
+  if (!open) return null;
+
+  const overlayStyle: CSSProperties = {
+    position: 'fixed',
+    inset: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  };
+
+  const dialogStyle: CSSProperties = {
+    backgroundColor: colors.surface0,
+    borderRadius: '12px',
+    border: `1px solid ${colors.surface1}`,
+    width,
+    maxWidth: '90vw',
+    maxHeight: '90vh',
+    display: 'flex',
+    flexDirection: 'column',
+    outline: 'none',
+    ...style,
+  };
+
+  const headerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '20px 24px 16px',
+    borderBottom: title ? `1px solid ${colors.surface1}` : undefined,
+    flexShrink: 0,
+  };
+
+  const bodyStyle: CSSProperties = {
+    padding: '20px 24px',
+    overflowY: 'auto',
+    flex: 1,
+    color: colors.text,
+    fontSize: '14px',
+    lineHeight: '1.6',
+  };
+
+  const footerStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    padding: '16px 24px 20px',
+    borderTop: `1px solid ${colors.surface1}`,
+    flexShrink: 0,
+  };
+
+  const modal = (
+    // Backdrop
+    <div
+      style={overlayStyle}
+      onClick={onClose}
+      role="presentation"
+    >
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? 'modal-title' : undefined}
+        tabIndex={-1}
+        style={dialogStyle}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        {(title != null) && (
+          <div style={headerStyle}>
+            <h2
+              id="modal-title"
+              style={{
+                margin: 0,
+                fontSize: '18px',
+                fontWeight: '600',
+                color: colors.text,
+              }}
+            >
+              {title}
+            </h2>
+            <button
+              aria-label="Close"
+              onClick={onClose}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: colors.overlay1,
+                fontSize: '20px',
+                lineHeight: 1,
+                padding: '0 4px',
+              }}
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        {children != null && (
+          <div style={bodyStyle}>{children}</div>
+        )}
+
+        {actions && actions.length > 0 && (
+          <div style={footerStyle}>
+            {actions.map((action) => (
+              <button
+                key={action.label}
+                onClick={action.onClick}
+                disabled={action.disabled}
+                style={{
+                  ...baseStyles.button[action.variant ?? 'secondary'],
+                  opacity: action.disabled ? 0.5 : 1,
+                  cursor: action.disabled ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {action.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  return createPortal(modal, document.body);
+}

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Sidebar, { type SidebarItem } from './Sidebar';
+
+const makeItems = (): SidebarItem[] => [
+  { id: 'home', label: 'Home', path: '/', active: true },
+  { id: 'settings', label: 'Settings', path: '/settings' },
+  { id: 'disabled', label: 'Disabled', path: '/disabled', disabled: true },
+];
+
+describe('Sidebar', () => {
+  it('renders all nav items', () => {
+    render(<Sidebar items={makeItems()} onNavigate={vi.fn()} />);
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  it('renders nav landmark with accessible label', () => {
+    render(<Sidebar items={makeItems()} onNavigate={vi.fn()} />);
+    expect(screen.getByRole('navigation', { name: 'Sidebar navigation' })).toBeInTheDocument();
+  });
+
+  it('marks active item with aria-current="page"', () => {
+    render(<Sidebar items={makeItems()} onNavigate={vi.fn()} />);
+    const homeItem = screen.getByRole('button', { name: 'Home' });
+    expect(homeItem).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('calls onNavigate when a non-disabled item is clicked', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<Sidebar items={makeItems()} onNavigate={onNavigate} />);
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    expect(onNavigate.mock.calls[0][0].id).toBe('settings');
+  });
+
+  it('does not call onNavigate when a disabled item is clicked', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<Sidebar items={makeItems()} onNavigate={onNavigate} />);
+    const disabledItem = screen.getByRole('button', { name: 'Disabled' });
+    await user.click(disabledItem);
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('activates item via Enter key', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<Sidebar items={makeItems()} onNavigate={onNavigate} />);
+    const settingsItem = screen.getByRole('button', { name: 'Settings' });
+    settingsItem.focus();
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates item via Space key', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<Sidebar items={makeItems()} onNavigate={onNavigate} />);
+    const settingsItem = screen.getByRole('button', { name: 'Settings' });
+    settingsItem.focus();
+    await user.keyboard(' ');
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders toggle button when onToggleCollapse is provided', () => {
+    render(
+      <Sidebar items={makeItems()} onNavigate={vi.fn()} onToggleCollapse={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument();
+  });
+
+  it('calls onToggleCollapse when toggle button is clicked', async () => {
+    const user = userEvent.setup();
+    const onToggleCollapse = vi.fn();
+    render(
+      <Sidebar items={makeItems()} onNavigate={vi.fn()} onToggleCollapse={onToggleCollapse} />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "Expand sidebar" label when collapsed', () => {
+    render(
+      <Sidebar
+        items={makeItems()}
+        onNavigate={vi.fn()}
+        collapsed={true}
+        onToggleCollapse={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument();
+  });
+
+  it('hides item labels in collapsed mode', () => {
+    const { container } = render(
+      <Sidebar items={makeItems()} onNavigate={vi.fn()} collapsed={true} />,
+    );
+    // Labels are not rendered as visible text nodes when collapsed
+    const nav = container.querySelector('nav') as HTMLElement;
+    expect(nav).toBeInTheDocument();
+    // The item labels should not appear as visible spans in collapsed mode
+    const visibleLabels = Array.from(nav.querySelectorAll('span')).filter(
+      (el) => el.textContent === 'Home',
+    );
+    expect(visibleLabels.length).toBe(0);
+  });
+
+  it('renders header content when not collapsed', () => {
+    render(
+      <Sidebar
+        items={makeItems()}
+        onNavigate={vi.fn()}
+        header={<span>My App</span>}
+      />,
+    );
+    expect(screen.getByText('My App')).toBeInTheDocument();
+  });
+
+  it('renders footer content', () => {
+    render(
+      <Sidebar
+        items={makeItems()}
+        onNavigate={vi.fn()}
+        footer={<span>v1.0.0</span>}
+      />,
+    );
+    expect(screen.getByText('v1.0.0')).toBeInTheDocument();
+  });
+
+  it('renders icon inside nav item', () => {
+    const itemsWithIcon: SidebarItem[] = [
+      { id: 'home', label: 'Home', icon: <span data-testid="home-icon">🏠</span> },
+    ];
+    render(<Sidebar items={itemsWithIcon} onNavigate={vi.fn()} />);
+    expect(screen.getByTestId('home-icon')).toBeInTheDocument();
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties, ReactNode, KeyboardEvent } from 'react';
 import { colors } from '../theme';
 
 export interface SidebarItem {
@@ -184,7 +184,7 @@ function SidebarNavItem({ item, collapsed, onNavigate }: SidebarNavItemProps) {
     if (!isDisabled) onNavigate(item);
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
+  function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       handleClick();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,231 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { colors } from '../theme';
+
+export interface SidebarItem {
+  /** Unique identifier for the item. */
+  id: string;
+  /** Display label. */
+  label: string;
+  /** Optional icon element. */
+  icon?: ReactNode;
+  /** Path or href (informational — used by onNavigate). */
+  path?: string;
+  /** Whether this item is currently active. */
+  active?: boolean;
+  /** Disable this item. */
+  disabled?: boolean;
+}
+
+export interface SidebarProps {
+  /** Navigation items to display. */
+  items: SidebarItem[];
+  /** Called when user clicks a non-disabled item. */
+  onNavigate: (item: SidebarItem) => void;
+  /** Whether the sidebar is in collapsed (icon-only) mode. */
+  collapsed?: boolean;
+  /** Called when the toggle button is clicked. */
+  onToggleCollapse?: () => void;
+  /** Sidebar title / logo area content. */
+  header?: ReactNode;
+  /** Footer area content. */
+  footer?: ReactNode;
+  /** Override sidebar root style. */
+  style?: CSSProperties;
+}
+
+const SIDEBAR_FULL_WIDTH = 220;
+const SIDEBAR_COLLAPSED_WIDTH = 56;
+
+export default function Sidebar({
+  items,
+  onNavigate,
+  collapsed = false,
+  onToggleCollapse,
+  header,
+  footer,
+  style,
+}: SidebarProps) {
+  const width = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_FULL_WIDTH;
+
+  const sidebarStyle: CSSProperties = {
+    width,
+    minWidth: width,
+    maxWidth: width,
+    backgroundColor: colors.mantle,
+    borderRight: `1px solid ${colors.surface0}`,
+    display: 'flex',
+    flexDirection: 'column',
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    transition: 'width 0.2s ease, min-width 0.2s ease, max-width 0.2s ease',
+    overflow: 'hidden',
+    ...style,
+  };
+
+  const headerAreaStyle: CSSProperties = {
+    padding: collapsed ? '16px 0' : '16px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: collapsed ? 'center' : 'space-between',
+    borderBottom: `1px solid ${colors.surface0}`,
+    minHeight: 56,
+    flexShrink: 0,
+  };
+
+  const navStyle: CSSProperties = {
+    flex: 1,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    padding: '8px 0',
+  };
+
+  const footerAreaStyle: CSSProperties = {
+    padding: collapsed ? '12px 0' : '12px 8px',
+    borderTop: `1px solid ${colors.surface0}`,
+    flexShrink: 0,
+  };
+
+  return (
+    <nav style={sidebarStyle} aria-label="Sidebar navigation">
+      {/* Header */}
+      <div style={headerAreaStyle}>
+        {!collapsed && header && (
+          <div
+            style={{
+              color: colors.text,
+              fontSize: '15px',
+              fontWeight: '600',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: 1,
+            }}
+          >
+            {header}
+          </div>
+        )}
+        {onToggleCollapse && (
+          <button
+            onClick={onToggleCollapse}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            title={collapsed ? 'Expand' : 'Collapse'}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: colors.overlay1,
+              fontSize: '16px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '4px',
+              borderRadius: '4px',
+              flexShrink: 0,
+            }}
+          >
+            {collapsed ? '›' : '‹'}
+          </button>
+        )}
+      </div>
+
+      {/* Nav items */}
+      <div style={navStyle}>
+        {items.map((item) => (
+          <SidebarNavItem
+            key={item.id}
+            item={item}
+            collapsed={collapsed}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+
+      {/* Footer */}
+      {footer && <div style={footerAreaStyle}>{footer}</div>}
+    </nav>
+  );
+}
+
+interface SidebarNavItemProps {
+  item: SidebarItem;
+  collapsed: boolean;
+  onNavigate: (item: SidebarItem) => void;
+}
+
+function SidebarNavItem({ item, collapsed, onNavigate }: SidebarNavItemProps) {
+  const isActive = item.active ?? false;
+  const isDisabled = item.disabled ?? false;
+
+  const baseItemStyle: CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    padding: collapsed ? '10px 0' : '9px 12px',
+    margin: '1px 6px',
+    borderRadius: '6px',
+    cursor: isDisabled ? 'not-allowed' : 'pointer',
+    color: isDisabled
+      ? colors.overlay0
+      : isActive
+        ? colors.blue
+        : colors.subtext1,
+    backgroundColor: isActive ? `${colors.blue}18` : 'transparent',
+    fontSize: '14px',
+    fontWeight: isActive ? '500' : '400',
+    textDecoration: 'none',
+    transition: 'background-color 0.15s, color 0.15s',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    justifyContent: collapsed ? 'center' : 'flex-start',
+    opacity: isDisabled ? 0.5 : 1,
+    userSelect: 'none',
+  };
+
+  function handleClick() {
+    if (!isDisabled) onNavigate(item);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={isDisabled ? -1 : 0}
+      aria-current={isActive ? 'page' : undefined}
+      aria-disabled={isDisabled}
+      aria-label={collapsed ? item.label : undefined}
+      title={collapsed ? item.label : undefined}
+      style={baseItemStyle}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {item.icon && (
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            fontSize: '16px',
+          }}
+        >
+          {item.icon}
+        </span>
+      )}
+      {!collapsed && (
+        <span
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {item.label}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatusBadge from './StatusBadge';
+
+describe('StatusBadge', () => {
+  it('renders with default label from status', () => {
+    render(<StatusBadge status="running" />);
+    expect(screen.getByText('Running')).toBeInTheDocument();
+  });
+
+  it('renders with custom label', () => {
+    render(<StatusBadge status="completed" label="Done" />);
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('renders all supported statuses without throwing', () => {
+    const statuses = [
+      'idle', 'running', 'completed', 'failed', 'pending',
+      'active', 'stopped', 'error', 'canceled',
+    ] as const;
+
+    for (const status of statuses) {
+      const { unmount } = render(<StatusBadge status={status} />);
+      unmount();
+    }
+  });
+
+  it('renders sm size', () => {
+    const { container } = render(<StatusBadge status="idle" size="sm" />);
+    // The badge wrapper should be rendered
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('renders lg size', () => {
+    const { container } = render(<StatusBadge status="failed" size="lg" />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('applies custom style', () => {
+    const { container } = render(
+      <StatusBadge status="pending" style={{ marginTop: '8px' }} />,
+    );
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.style.marginTop).toBe('8px');
+  });
+
+  it('capitalises status as label by default', () => {
+    render(<StatusBadge status="failed" />);
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('renders a dot element alongside the label', () => {
+    const { container } = render(<StatusBadge status="running" />);
+    // span > span (dot) + text
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,106 @@
+import type { CSSProperties } from 'react';
+import { colors, statusColors } from '../theme';
+
+export type StatusValue =
+  | 'idle'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'pending'
+  | 'active'
+  | 'stopped'
+  | 'error'
+  | 'canceled';
+
+export type StatusBadgeSize = 'sm' | 'md' | 'lg';
+
+export interface StatusBadgeProps {
+  /** The status to display. */
+  status: StatusValue;
+  /** Optional label override — defaults to the status string. */
+  label?: string;
+  /** Badge size. Default: 'md' */
+  size?: StatusBadgeSize;
+  /** Override container style. */
+  style?: CSSProperties;
+}
+
+const dotSize: Record<StatusBadgeSize, number> = {
+  sm: 6,
+  md: 8,
+  lg: 10,
+};
+
+const fontSize: Record<StatusBadgeSize, string> = {
+  sm: '11px',
+  md: '13px',
+  lg: '15px',
+};
+
+const padding: Record<StatusBadgeSize, string> = {
+  sm: '2px 6px',
+  md: '3px 8px',
+  lg: '4px 10px',
+};
+
+/** Inline keyframe style injected once. */
+let pulseInjected = false;
+function ensurePulseKeyframes() {
+  if (pulseInjected || typeof document === 'undefined') return;
+  pulseInjected = true;
+  const style = document.createElement('style');
+  style.textContent = `
+    @keyframes workflow-ui-pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.35; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+export default function StatusBadge({
+  status,
+  label,
+  size = 'md',
+  style,
+}: StatusBadgeProps) {
+  ensurePulseKeyframes();
+
+  const color = statusColors[status] ?? colors.overlay0;
+  const isRunning = status === 'running' || status === 'active';
+  const displayLabel = label ?? status.charAt(0).toUpperCase() + status.slice(1);
+
+  const containerStyle: CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    backgroundColor: `${color}22`,
+    border: `1px solid ${color}55`,
+    borderRadius: '9999px',
+    padding: padding[size],
+    fontFamily: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    fontSize: fontSize[size],
+    fontWeight: '500',
+    color,
+    whiteSpace: 'nowrap',
+    ...style,
+  };
+
+  const dotStyle: CSSProperties = {
+    width: dotSize[size],
+    height: dotSize[size],
+    borderRadius: '50%',
+    backgroundColor: color,
+    flexShrink: 0,
+    ...(isRunning
+      ? { animation: 'workflow-ui-pulse 1.4s ease-in-out infinite' }
+      : {}),
+  };
+
+  return (
+    <span style={containerStyle}>
+      <span style={dotStyle} />
+      {displayLabel}
+    </span>
+  );
+}

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -99,7 +99,7 @@ export default function StatusBadge({
 
   return (
     <span style={containerStyle}>
-      <span style={dotStyle} />
+      <span style={dotStyle} aria-hidden="true" role="presentation" />
       {displayLabel}
     </span>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,22 @@
+export { default as StatusBadge } from './StatusBadge';
+export type { StatusBadgeProps, StatusValue, StatusBadgeSize } from './StatusBadge';
+
+export { default as DataTable } from './DataTable';
+export type {
+  DataTableProps,
+  DataTableColumn,
+  SortState,
+  SortDirection,
+} from './DataTable';
+
+export { default as Modal } from './Modal';
+export type { ModalProps, ModalAction } from './Modal';
+
+export { default as LoadingSpinner } from './LoadingSpinner';
+export type { LoadingSpinnerProps, LoadingSpinnerSize } from './LoadingSpinner';
+
+export { default as ErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps } from './ErrorBoundary';
+
+export { default as Sidebar } from './Sidebar';
+export type { SidebarProps, SidebarItem } from './Sidebar';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,29 @@ export type { SSEConfig } from './sse';
 
 // Theme
 export { colors, statusColors, baseStyles } from './theme';
+
+// Components
+export {
+  StatusBadge,
+  DataTable,
+  Modal,
+  LoadingSpinner,
+  ErrorBoundary,
+  Sidebar,
+} from './components';
+export type {
+  StatusBadgeProps,
+  StatusValue,
+  StatusBadgeSize,
+  DataTableProps,
+  DataTableColumn,
+  SortState,
+  SortDirection,
+  ModalProps,
+  ModalAction,
+  LoadingSpinnerProps,
+  LoadingSpinnerSize,
+  ErrorBoundaryProps,
+  SidebarProps,
+  SidebarItem,
+} from './components';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
         'auth/index': resolve(__dirname, 'src/auth/index.ts'),
         'sse/index': resolve(__dirname, 'src/sse/index.ts'),
         'theme/index': resolve(__dirname, 'src/theme/index.ts'),
+        'components/index': resolve(__dirname, 'src/components/index.ts'),
       },
       formats: ['es', 'cjs'],
     },


### PR DESCRIPTION
## Summary

- **StatusBadge**: Color-coded status indicator with animated pulse for running/active states, using theme `statusColors`
- **DataTable**: Sortable, paginated data table with generic TypeScript row types, client-side sort, and custom cell renderers
- **Modal**: Portal-rendered dialog with Escape key and backdrop-click dismiss, action buttons, and focus management
- **LoadingSpinner**: CSS-animated loading indicator with configurable size, color, and optional message
- **ErrorBoundary**: React class error boundary with default fallback UI and customizable `fallback` render prop
- **Sidebar**: Collapsible navigation sidebar with icon support, active state, disabled items, and smooth width transition

All components:
- Use inline styles with the existing Catppuccin Mocha theme (`colors`, `statusColors`, `baseStyles`)
- Are fully typed with TypeScript
- Have no external UI library dependencies
- Are exported from both the package root and the `./components` subpath

## Test plan

- [x] All 77 component and existing tests pass (`npm test`)
- [x] Build succeeds with `./components` dist entries (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] `./components` export added to `package.json` exports map
- [x] `components/index` entry added to `vite.config.ts`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)