### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/workflow-ui/security/code-scanning/1](https://github.com/GoCodeAlone/workflow-ui/security/code-scanning/1)

In general, fix this by explicitly defining a `permissions` block in the workflow (either at the top level or per-job) that grants only the minimal read permissions needed, instead of relying on inherited defaults. For a simple Node CI that just checks out code and runs tests/build, `contents: read` is sufficient, and optionally `packages: read` if private GitHub Packages are used.

For this specific workflow in `.github/workflows/ci.yml`, add a top-level `permissions` section just below the `name: CI` line so it applies to all jobs. Set it to the minimal recommended values, e.g.:

```yaml
permissions:
  contents: read
```

If you know the workflow pulls from GitHub Packages, you could additionally include `packages: read`, but based only on the provided snippet, `contents: read` is enough and does not change existing functionality: checkout and read operations will still work, and no write capabilities will be available to the token. No imports or other code changes are needed; this is purely a YAML configuration addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
